### PR TITLE
docs: Fix closing square bracket for CISA SBOM link

### DIFF
--- a/reference/sbom_naming.md
+++ b/reference/sbom_naming.md
@@ -1,6 +1,6 @@
 # Best Practices for Naming and Directory Conventions for SBOMs (Software Bill of Materials) in Open Source Projects
 
-The [Software Bill of Materials (SBOM)}(https://www.cisa.gov/sbom) plays a vital role in providing visibility & transparency into the software supply chain. Using SBOM standards such as [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.dev/) ensures interoperability, accurate dependency tracking, and efficient vulnerability management. Here are some best practices for naming and directory conventions when creating and managing SBOMs.
+The [Software Bill of Materials (SBOM)](https://www.cisa.gov/sbom) plays a vital role in providing visibility & transparency into the software supply chain. Using SBOM standards such as [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.dev/) ensures interoperability, accurate dependency tracking, and efficient vulnerability management. Here are some best practices for naming and directory conventions when creating and managing SBOMs.
 
 ## Scope
 


### PR DESCRIPTION
The link doesn't render correctly due to a curly end bracket being where a square end bracket should be (a typo).