### PR TITLE
Update SBOM-wiki./index.md with corrected spelling and link for Working Groups

### DIFF
--- a/SBOM-wiki/index.md
+++ b/SBOM-wiki/index.md
@@ -34,8 +34,8 @@ features:
     details: Wondering who requires SBOM and want to see a list referencing the sources? Here's a list of laws, guidelines and requirements mandating SBOMs.
     link: /sbom-compliance
   - title: Working Groups
-    details: Do you want to join, contribute or ask questions. Her is a list of working groups.
-    link: sbom-everywhere-sig
+    details: Do you want to join, contribute or ask questions. Here is a list of working groups.
+    link: /sbom-working-groups.md
 ---
 
 <style>

--- a/SBOM-wiki/index.md
+++ b/SBOM-wiki/index.md
@@ -35,7 +35,7 @@ features:
     link: /sbom-compliance
   - title: Working Groups
     details: Do you want to join, contribute or ask questions. Here is a list of working groups.
-    link: /sbom-working-groups.md
+    link: /sbom-working-groups
 ---
 
 <style>


### PR DESCRIPTION
The Working Groups section of the homepage at sbom-catalog.openssf.org had here misspelled and had a broken link. This updates the index.md file to fix.