### PR TITLE
Update SBOM-wiki/about-us.md to fix Charter link

### DIFF
--- a/SBOM-wiki/about-us.md
+++ b/SBOM-wiki/about-us.md
@@ -117,4 +117,4 @@ NTIA's legwork has been a guiding source having done the most comprehensive rese
 
 ## Governance
 
-The [CHARTER.md](https://github.com/ossf/sbom-everywhere/CHARTER.md) outlines the scope and governance of our group activities.
+The [CHARTER.md](https://github.com/ossf/sbom-everywhere/blob/main/CHARTER.md) outlines the scope and governance of our group activities.


### PR DESCRIPTION
The Charter link at the bottom of about-us page results in a not found error. This updates the link to the file as it resolves on GitHub.