### PR TITLE
Add Pitloom to SBOM-Catalog data

### DIFF
--- a/SBOM-Catalog/public/data.yaml
+++ b/SBOM-Catalog/public/data.yaml
@@ -7187,7 +7187,7 @@
   Link: https://github.com/bact/pitloom
   Name: Pitloom
   Publisher: Arthit Suriyawongkul
-  Source: Python project file, Hatchling dynamic build information, AI model metadata
+  Source: AI & human reviewed
   Standards:
     - SPDX
   Summary: 'Pitloom - SBOM generator for AI models and Python projects

--- a/SBOM-Catalog/public/data.yaml
+++ b/SBOM-Catalog/public/data.yaml
@@ -7194,11 +7194,14 @@
 
     Pitloom is a command-line tool, a library, and a GitHub Action that
     generates SPDX 3 SBOMs for AI models and Python projects.
-    
+
     It reads metadata directly from Python packages, build information, and
     AI models (FastText, GGUF, ONNX, PyTorch, Safetensors), producing
     standardized SPDX 3 JSON artifacts.
     It runs on any system that support Python 3.10 or later.
+
+    When used as a Hatchling build hook, it embeds the generated SBOM
+    directly into the Python distribution package (wheel).
 
     Key Features:
 

--- a/SBOM-Catalog/public/data.yaml
+++ b/SBOM-Catalog/public/data.yaml
@@ -7179,3 +7179,44 @@
     - Analyze
     - Deployment
     - Container
+- Abilities:
+    - Generate
+  Languages:
+    - Python
+  License: Apache-2.0
+  Link: https://github.com/bact/pitloom
+  Name: Pitloom
+  Publisher: Arthit Suriyawongkul
+  Source: Python project file, Hatchling dynamic build information, AI model metadata
+  Standards:
+    - SPDX
+  Summary: 'Pitloom - SBOM generator for AI models and Python projects
+
+    Pitloom is a command-line tool, a library, and a GitHub Action that
+    generates SPDX 3 SBOMs for AI models and Python projects.
+    
+    It reads metadata directly from Python packages, build information, and
+    AI models (FastText, GGUF, ONNX, PyTorch, Safetensors), producing
+    standardized SPDX 3 JSON artifacts.
+    It runs on any system that support Python 3.10 or later.
+
+    Key Features:
+
+    - Gerenates SBOMs including project dependencies and license information
+
+    - Generates SBOMs of AI model from AI model file
+
+    - Generates SBOMs of AI model from Hugging Face Hub URL/ID
+
+    - Generates SBOMs of a Python project and embed the SBOM into the Python
+      wheel (PEP 770), using Hatchling dynamic build information
+
+    - Generates SBOMs of a Python project from command line interface and
+      from programmatic Python API
+
+    The tool is available as a PyPI package installable via pip and also
+    available as GitHub Action for integration into CI/CD pipelines.
+    It generates SPDX 3 JSON which can be consume by any JSON-LD processor.'
+  Types:
+    - Source
+    - Build


### PR DESCRIPTION
Add **Pitloom** https://github.com/bact/pitloom (Apache-2.0) to `SBOM-Catalog/public/data.yaml`

Pitloom automates the generation of SPDX 3-compliant SBOMs for AI models and Python projects. It reads metadata directly from Python packages and AI models (GGUF, ONNX, PyTorch, Safetensors), producing standardized SPDX 3 JSON artifacts -- as a CLI, a library, or a native Hatchling build hook.

When used as a Hatchling build hook, it embeds the generated SBOM directly into the Python distribution package (wheel).